### PR TITLE
fix homepage link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -70,8 +70,7 @@
   <header class="page-header" role="banner" dir="rtl">
     <div class="main-title">
       <div id="rightElement">
-        <a href="https://www.linksforisrael.com/" target="_blank" rel="noopener noreferrer" id="homepageLink">
-
+        <a href="/" id="homepageLink">
           <h1>
             <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
               <g clip-path="url(#clip0_7_707)">


### PR DESCRIPTION
1. make link relative (works on local, and if we change hostname)
1. stay in the same tab (whole point of link I think)