### PR TITLE
Header.tsx - developer help button directs to contribution page

### DIFF
--- a/app/components/Header/Header.tsx
+++ b/app/components/Header/Header.tsx
@@ -23,7 +23,7 @@ function HelpUsButton() {
 	return (
 		<a
 			className="contribute-button"
-			href="https://chat.whatsapp.com/JjD8eijWfDXD10QbM2VyaX"
+			href="https://github.com/4tals/LinksForIsrael/blob/main/docs/contribute.md"
 			target="_blank"
 			rel="noopener noreferrer"
 		>


### PR DESCRIPTION
and not WhatsApp group - this was already done in the Jekyll version and somehow got lost during the merge