### PR TITLE
Update new_initiative_workflow.yml - downgrade Python version

### DIFF
--- a/.github/workflows/new_initiative_workflow.yml
+++ b/.github/workflows/new_initiative_workflow.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check Label and Title
         id: check
@@ -29,9 +29,9 @@ jobs:
 
       - name: Set up Python
         if: steps.check.outputs.match == 'true'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.10"
 
       - name: Install dependencies
         if: steps.check.outputs.match == 'true'


### PR DESCRIPTION
3.12 is not compatible with our dependencies, resulting in failures:
https://github.com/4tals/LinksForIsrael/actions/runs/6658964272/job/18097155583#step:5:302

See: https://github.com/langchain-ai/langchain/issues/11479